### PR TITLE
Revert "Fix for #3, Support keymap for {n}gcc"

### DIFF
--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -88,7 +88,6 @@ function M.operator(mode)
 end
 
 function M.comment_toggle(line_start, line_end)
-  line_end = vim.v.count ~= 0 and line_end + vim.v.count - 1 or line_end
   local left, right = M.get_comment_wrapper()
   if not left or not right then return end
 


### PR DESCRIPTION
Reverts terrortylor/nvim-comment#13

found an edge case that I wasn't happy with, and actually behaviour can be acheived with gc2j or gc3k etc
whilst 3gcc does work, it breaks the dot repeatable atm