### PR TITLE
Stop empty lines setting indentation to zero

### DIFF
--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -85,6 +85,7 @@ function M.comment_toggle(line_start, line_end)
   local indent
 
   for _,v in pairs(lines) do
+    if line == '\n' then goto empty_line
     if v:find('^%s*' .. esc_left) then
       commented_lines_counter = commented_lines_counter + 1
     elseif v:match("^%s*$") then
@@ -96,6 +97,7 @@ function M.comment_toggle(line_start, line_end)
     if not indent or string.len(line_indent) < string.len(indent) then
       indent = line_indent
     end
+    ::empty_line::
   end
 
   for i,v in pairs(lines) do

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -85,7 +85,7 @@ function M.comment_toggle(line_start, line_end)
   local indent
 
   for _,v in pairs(lines) do
-    if line == '\n' then goto empty_line
+    if line == '\n' then goto empty_line end
     if v:find('^%s*' .. esc_left) then
       commented_lines_counter = commented_lines_counter + 1
     elseif v:match("^%s*$") then

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -85,7 +85,7 @@ function M.comment_toggle(line_start, line_end)
   local indent
 
   for _,v in pairs(lines) do
-    if line == '' then goto empty_line end
+    if l:match("^%s*$") then goto empty_line end
     if v:find('^%s*' .. esc_left) then
       commented_lines_counter = commented_lines_counter + 1
     elseif v:match("^%s*$") then
@@ -94,6 +94,7 @@ function M.comment_toggle(line_start, line_end)
     -- TODO what if already commented line has smallest indent?
     -- TODO no tests for this indent block
     local line_indent = v:match("^%s+") or ""
+
     if not indent or string.len(line_indent) < string.len(indent) then
       indent = line_indent
     end

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -92,12 +92,12 @@ function M.comment_toggle(line_start, line_end)
     end
     -- TODO what if already commented line has smallest indent?
     -- TODO no tests for this indent block
-    if v:match("^%s*$") then goto empty_line end
-    local line_indent = v:match("^%s+") or ""
-    if not indent or string.len(line_indent) < string.len(indent) then
-      indent = line_indent
+    if not v:match("^%s*$") then
+      local line_indent = v:match("^%s+") or ""
+      if not indent or string.len(line_indent) < string.len(indent) then
+        indent = line_indent
+      end
     end
-    ::empty_line::
   end
 
   for i,v in pairs(lines) do

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -92,7 +92,7 @@ function M.comment_toggle(line_start, line_end)
     end
     -- TODO what if already commented line has smallest indent?
     -- TODO no tests for this indent block
-    if line:match("^%s*$") then goto empty_line end
+    if v:match("^%s*$") then goto empty_line end
     local line_indent = v:match("^%s+") or ""
     if not indent or string.len(line_indent) < string.len(indent) then
       indent = line_indent

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -85,7 +85,6 @@ function M.comment_toggle(line_start, line_end)
   local indent
 
   for _,v in pairs(lines) do
-    if l:match("^%s*$") then goto empty_line end
     if v:find('^%s*' .. esc_left) then
       commented_lines_counter = commented_lines_counter + 1
     elseif v:match("^%s*$") then
@@ -93,8 +92,8 @@ function M.comment_toggle(line_start, line_end)
     end
     -- TODO what if already commented line has smallest indent?
     -- TODO no tests for this indent block
+    if line:match("^%s*$") then goto empty_line end
     local line_indent = v:match("^%s+") or ""
-
     if not indent or string.len(line_indent) < string.len(indent) then
       indent = line_indent
     end

--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -85,7 +85,7 @@ function M.comment_toggle(line_start, line_end)
   local indent
 
   for _,v in pairs(lines) do
-    if line == '\n' then goto empty_line end
+    if line == '' then goto empty_line end
     if v:find('^%s*' .. esc_left) then
       commented_lines_counter = commented_lines_counter + 1
     elseif v:match("^%s*$") then


### PR DESCRIPTION
Added a check so comment indentation can not be set by empty lines. Fixes #31 