### PR TITLE
Feat: ignore trailing whitespace in commentchars

### DIFF
--- a/lua/nvim_comment.lua
+++ b/lua/nvim_comment.lua
@@ -54,7 +54,7 @@ function M.comment_line(l, indent, left, right, comment_empty, comment_empty_tri
 
 	local line_empty = l:match("^%s*$")
 
-	-- standarise indentation before adding
+	-- standardise indentation before adding
 	local line = l:gsub("^" .. indent, "")
 	if right then
 		line = line .. right
@@ -82,7 +82,12 @@ function M.uncomment_line(l, left, right, comment_empty_trim_whitespace)
 		end
 	end
 
-	return line:gsub(vim.pesc(left), "", 1)
+	-- Ignore trailing whitespace in comment chars. This allows
+	-- uncommenting the line '--line' to 'line' even if the comment string is '-- '.
+	local trailing_ws_amount = #left:match("%s+$")
+	local left_stripped = left:sub(1, #left - trailing_ws_amount)
+	local pattern = vim.pesc(left_stripped) .. ("%s?"):rep(trailing_ws_amount)
+	return line:gsub(pattern, "", 1)
 end
 
 function M.operator(mode)

--- a/tests/comment_spec.lua
+++ b/tests/comment_spec.lua
@@ -40,8 +40,6 @@ end
 		})
 	end)
 
-	after_each(function() end)
-
 	it("Should comment/uncomment line with dot repeatable", function()
 		local expected = [[
 -- local function dummy_func()
@@ -100,6 +98,24 @@ end
 		runCommandAndAssert(1, "gc2j", input)
 		-- comment, via dot
 		runCommandAndAssert(1, ".", expected)
+	end)
+
+	it("Should ignore trailing whitespace in commentstring when uncommenting", function()
+		local input = [[
+--local function dummy_func() end
+]]
+		local expected_uncommented = [[
+local function dummy_func() end
+]]
+		local expected_commented = [[
+-- local function dummy_func() end
+]]
+
+		setUpBuffer(input, "lua")
+		-- Uncomment
+		runCommandAndAssert(1, "gcc", expected_uncommented)
+		-- Comment
+		runCommandAndAssert(1, "gcc", expected_commented)
 	end)
 
 	it("Should comment out another pararaph via dot", function()
@@ -316,7 +332,7 @@ local baz = 'baz'
 		runCommandAndAssert(1, "gcic", expected)
 	end)
 
-	it("Should handle text obeject at botton of buffer", function()
+	it("Should handle text object at bottom of buffer", function()
 		local expected = [[
 -- local foo = 'foo'
 -- local bar = 'bar'


### PR DESCRIPTION
Before this change the following line could not be uncommented in a Lua file (even though it is a commented line) because the commentstring for Lua files is `--%s`:
```lua
--local fn = vim.fn
```
After this change the line will be uncommented to `local fn = vim.fn`, as expected.

Let me know if you would prefer a setting for this behavior instead that users can opt-out from. 